### PR TITLE
feat: add maker (limit) order support

### DIFF
--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -379,7 +379,6 @@ abstract contract Dispatcher is NFTImmutables, Payments, V2SwapRouter, V3SwapRou
                     uint256 takerAmount;
                     uint256 nonce;
                     uint256 deadline;
-                    bytes signature;
                     assembly {
                         recipient := calldataload(inputs.offset)
                         amountIn := calldataload(add(inputs.offset, 0x20))
@@ -391,9 +390,9 @@ abstract contract Dispatcher is NFTImmutables, Payments, V2SwapRouter, V3SwapRou
                         takerAmount := calldataload(add(inputs.offset, 0xe0))
                         nonce := calldataload(add(inputs.offset, 0x100))
                         deadline := calldataload(add(inputs.offset, 0x120))
-                        signature := calldataload(add(inputs.offset, 0x140))
                     }
                     address payer = payerIsUser ? lockedBy : address(this);
+                    bytes calldata signature = inputs.toBytes(10);
                     fill(
                         payer,
                         map(recipient),

--- a/contracts/base/Dispatcher.sol
+++ b/contracts/base/Dispatcher.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.17;
 
 import {CurveV1Router} from '../modules/curve/v1/CurveV1Router.sol';
+import {MakerOrder, MakerOrderFiller} from '../modules/MakerOrderFiller.sol';
 import {V2SwapRouter} from '../modules/uniswap/v2/V2SwapRouter.sol';
 import {V3SwapRouter} from '../modules/uniswap/v3/V3SwapRouter.sol';
 import {BytesLib} from '../modules/uniswap/v3/BytesLib.sol';
@@ -19,7 +20,7 @@ import {ICryptoPunksMarket} from '../interfaces/external/ICryptoPunksMarket.sol'
 
 /// @title Decodes and Executes Commands
 /// @notice Called by the UniversalRouter contract to efficiently decode and execute a singular command
-abstract contract Dispatcher is NFTImmutables, Payments, V2SwapRouter, V3SwapRouter, CurveV1Router, Callbacks, LockAndMsgSender {
+abstract contract Dispatcher is NFTImmutables, Payments, V2SwapRouter, V3SwapRouter, CurveV1Router, MakerOrderFiller, Callbacks, LockAndMsgSender {
     using BytesLib for bytes;
 
     error InvalidCommandType(uint256 commandType);
@@ -367,8 +368,49 @@ abstract contract Dispatcher is NFTImmutables, Payments, V2SwapRouter, V3SwapRou
                         amountOutMin := calldataload(add(inputs.offset, 0x80))
                     }
                     curveV1Exchange(poolAddress, inputTokenAddress, outputTokenAddress, amountIn, amountOutMin);
-                } else {
-                // placeholder area for commands 0x23-0x3f
+            } else if (command == Commands.MAKER_ORDER) {
+                    address recipient;
+                    uint256 amountIn;
+                    bool payerIsUser;
+                    address makerToken;
+                    address takerToken;
+                    address maker;
+                    uint256 makerAmount;
+                    uint256 takerAmount;
+                    uint256 nonce;
+                    uint256 deadline;
+                    bytes signature;
+                    assembly {
+                        recipient := calldataload(inputs.offset)
+                        amountIn := calldataload(add(inputs.offset, 0x20))
+                        payerIsUser := calldataload(add(inputs.offset, 0x40))
+                        makerToken := calldataload(add(inputs.offset, 0x60))
+                        takerToken := calldataload(add(inputs.offset, 0x80))
+                        maker := calldataload(add(inputs.offset, 0xa0))
+                        makerAmount := calldataload(add(inputs.offset, 0xc0))
+                        takerAmount := calldataload(add(inputs.offset, 0xe0))
+                        nonce := calldataload(add(inputs.offset, 0x100))
+                        deadline := calldataload(add(inputs.offset, 0x120))
+                        signature := calldataload(add(inputs.offset, 0x140))
+                    }
+                    address payer = payerIsUser ? lockedBy : address(this);
+                    fill(
+                        payer,
+                        map(recipient),
+                        amountIn,
+                        MakerOrder({
+                            makerToken: makerToken,
+                            takerToken: takerToken,
+                            maker: maker,
+                            makerAmount: makerAmount,
+                            takerAmount: takerAmount,
+                            nonce: nonce,
+                            deadline: deadline
+                        }),
+                        signature
+                    );
+            } else {
+                // placeholder area for commands 0x25-0x3f
                 revert InvalidCommandType(command);
             }
         }

--- a/contracts/libraries/Commands.sol
+++ b/contracts/libraries/Commands.sol
@@ -74,4 +74,5 @@ library Commands {
     // COMMAND_PLACEHOLDER for 0x23 to 0x3f (unused by Uniswap)
     // Added by SwapNet protocol
     uint256 constant CURVE_V1 = 0x23;
+    uint256 constant MAKER_ORDER = 0x24;
 }

--- a/contracts/modules/MakerOrderFiller.sol
+++ b/contracts/modules/MakerOrderFiller.sol
@@ -18,36 +18,21 @@ struct MakerOrder {
 /// @title Filler for MakerOrder
 abstract contract MakerOrderFiller is Permit2Payments {
 
-    bytes internal constant ORDER_TYPE = abi.encodePacked(
-        "MakerOrder(",
-        "address makerToken,",
+    bytes internal constant ORDER_WITNESS_TYPE = abi.encodePacked(
+        "MakerOrderWitness(",
         "address takerToken,",
-        "address maker,",
-        "uint256 makerAmount,",
-        "uint256 takerAmount,",
-        "uint256 nonce,",
-        "uint256 deadline)"
+        "uint256 takerAmount)"
     );
-    bytes32 internal constant ORDER_TYPE_HASH = keccak256(ORDER_TYPE);
+    bytes32 internal constant ORDER_WITNESS_TYPE_HASH = keccak256(ORDER_WITNESS_TYPE);
 
     string private constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
-    string internal constant PERMIT2_ORDER_TYPE = string(abi.encodePacked("MakerOrder witness)", ORDER_TYPE, TOKEN_PERMISSIONS_TYPE));
+    string internal constant PERMIT2_ORDER_WITNESS_TYPE = string(abi.encodePacked("MakerOrderWitness witness)", ORDER_WITNESS_TYPE, TOKEN_PERMISSIONS_TYPE));
 
-    /// @notice hash the given order
-    /// @param order the order to hash
+    /// @notice hash the given order witness
     /// @return the eip-712 order hash
-    function hash(MakerOrder memory order) internal pure returns (bytes32) {
+    function hash(address takerToken, uint256 takerAmount) internal pure returns (bytes32) {
         return keccak256(
-            abi.encode(
-                ORDER_TYPE_HASH,
-                order.makerToken,
-                order.takerToken,
-                order.maker,
-                order.makerAmount,
-                order.takerAmount,
-                order.nonce,
-                order.deadline
-            )
+            abi.encode(ORDER_WITNESS_TYPE_HASH, takerToken, takerAmount)
         );
     }
 
@@ -78,8 +63,8 @@ abstract contract MakerOrderFiller is Permit2Payments {
             }),
             ISignatureTransfer.SignatureTransferDetails({to: recipient, requestedAmount: amountOut}),
             makerOrder.maker,
-            hash(makerOrder),
-            PERMIT2_ORDER_TYPE,
+            hash(makerOrder.takerToken, makerOrder.takerAmount),
+            PERMIT2_ORDER_WITNESS_TYPE,
             signature
         );
     }

--- a/contracts/modules/MakerOrderFiller.sol
+++ b/contracts/modules/MakerOrderFiller.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.17;
+
+import {ERC20} from 'solmate/src/tokens/ERC20.sol';
+import {ISignatureTransfer} from 'permit2/src/interfaces/ISignatureTransfer.sol';
+import {Permit2Payments} from './Permit2Payments.sol';
+
+struct MakerOrder {
+    address makerToken;
+    address takerToken;
+    address maker;
+    uint256 makerAmount;
+    uint256 takerAmount;
+    uint256 nonce;
+    uint256 deadline;
+}
+
+// error EmbededError(uint256 errorCode);
+
+/// @title Filler for MakerOrder
+abstract contract MakerOrderFiller is Permit2Payments {
+
+    bytes internal constant ORDER_TYPE = abi.encodePacked(
+        "MakerOrder(",
+        "address makerToken,",
+        "address takerToken,",
+        "address maker,",
+        "uint256 makerAmount,",
+        "uint256 takerAmount,",
+        "uint256 nonce,",
+        "uint256 deadline)"
+    );
+    bytes32 internal constant ORDER_TYPE_HASH = keccak256(ORDER_TYPE);
+
+    string private constant TOKEN_PERMISSIONS_TYPE = "TokenPermissions(address token,uint256 amount)";
+    string internal constant PERMIT2_ORDER_TYPE = string(abi.encodePacked("MakerOrder witness)", ORDER_TYPE, TOKEN_PERMISSIONS_TYPE));
+
+    /// @dev Permit2 address
+    ISignatureTransfer internal immutable PERMIT2;
+
+    constructor(address permit2) {
+        PERMIT2 = ISignatureTransfer(permit2);
+    }
+
+    /// @notice hash the given order
+    /// @param order the order to hash
+    /// @return the eip-712 order hash
+    function hash(MakerOrder memory order) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                ORDER_TYPE_HASH,
+                order.makerToken,
+                order.takerToken,
+                order.maker,
+                order.makerAmount,
+                order.takerAmount,
+                order.nonce,
+                order.deadline
+            )
+        );
+    }
+
+    /// @notice Swap for the user by filling a maker order
+    /// @param makerOrder The maker's order
+    /// @param amountIn The amount of input tokens to exchange
+    /// @param payer The address of payer
+    /// @param recipient The recipient of output (maker) token
+    function fill(
+        address payer,
+        address recipient,
+        uint256 amountIn,
+        MakerOrder memory makerOrder,
+        bytes memory signature
+    ) internal {
+        payOrPermit2Transfer(makerOrder.takerToken, payer, recipient, amountIn);
+
+        uint256 amountOut = amountIn * makerOrder.makerAmount / makerOrder.takerAmount;
+        PERMIT2.permitWitnessTransferFrom(
+            ISignatureTransfer.PermitTransferFrom({
+                permitted: ISignatureTransfer.TokenPermissions({
+                    token: makerOrder.makerToken,
+                    amount: makerOrder.makerAmount
+                }),
+                nonce: makerOrder.nonce,
+                deadline: makerOrder.deadline
+            }),
+            ISignatureTransfer.SignatureTransferDetails({to: recipient, requestedAmount: amountOut}),
+            makerOrder.maker,
+            hash(makerOrder),
+            PERMIT2_ORDER_TYPE,
+            signature
+        );
+        // revert EmbededError(amountOutMinimum);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -31,6 +31,9 @@ export default {
         url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,
         blockNumber: 15360000,
       },
+      accounts: {
+          count: 10
+      }
     },
     mainnet: {
       url: `https://mainnet.infura.io/v3/${process.env.INFURA_API_KEY}`,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "@uniswap/v2-core": "1.0.1",
     "@uniswap/v3-core": "1.0.0",
+    "@uniswap/permit2-sdk": "1.2.0",
+    "@ethereumjs/util": "9.0.1",
     "@openzeppelin/contracts": "4.7.0"
   },
   "devDependencies": {

--- a/test/integration-tests/MakerOrderFiller.test.ts
+++ b/test/integration-tests/MakerOrderFiller.test.ts
@@ -1,0 +1,371 @@
+import type { Contract } from '@ethersproject/contracts'
+import { TransactionReceipt } from '@ethersproject/abstract-provider'
+import { ecrecover, ecsign, hexToBytes, toRpcSig } from '@ethereumjs/util'
+import { expect } from './shared/expect'
+import { BigNumber, BigNumberish, Wallet } from 'ethers'
+import { config } from "hardhat";
+import { Permit2, UniversalRouter } from '../../typechain'
+import { abi as TOKEN_ABI } from '../../artifacts/solmate/src/tokens/ERC20.sol/ERC20.json'
+import { resetFork, WETH, DAI } from './shared/mainnetForkHelpers'
+import {
+  ADDRESS_THIS,
+  ALICE_ADDRESS,
+  DEADLINE,
+  MAX_UINT,
+  MAX_UINT160,
+  MSG_SENDER,
+} from './shared/constants'
+import { expandTo18DecimalsBN } from './shared/helpers'
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import deployUniversalRouter, { deployPermit2 } from './shared/deployUniversalRouter'
+import { RoutePlanner, CommandType, ROUTER_AS_RECIPIENT, SENDER_AS_RECIPIENT } from './shared/planner'
+import hre from 'hardhat'
+import { SignatureTransfer } from '@uniswap/permit2-sdk'
+const { ethers } = hre
+
+describe('Maker order filler tests:', () => {
+  let alice: SignerWithAddress
+  let taker: SignerWithAddress
+  let maker: SignerWithAddress
+  let router: UniversalRouter
+  let permit2: Permit2
+  let takerTokenContract: Contract
+  let makerTokenContract: Contract
+  let planner: RoutePlanner
+
+  const makerAmount: BigNumber = expandTo18DecimalsBN(10);
+  const takerAmount: BigNumber = expandTo18DecimalsBN(200);
+  const nonce: string = '0x0';
+  const chainId: number = hre.network.config.chainId ?? 1;
+  let signature: string;
+
+  beforeEach(async () => {
+    await resetFork()
+    await hre.network.provider.request({
+      method: 'hardhat_impersonateAccount',
+      params: [ALICE_ADDRESS],
+    })
+    alice = await ethers.getSigner(ALICE_ADDRESS)
+    taker = (await ethers.getSigners())[1]
+    maker = (await ethers.getSigners())[2]
+
+    takerTokenContract = new ethers.Contract(DAI.address, TOKEN_ABI, taker)
+    makerTokenContract = new ethers.Contract(WETH.address, TOKEN_ABI, taker)
+    permit2 = (await deployPermit2()) as Permit2
+    router = (await deployUniversalRouter(permit2)).connect(taker) as UniversalRouter
+    planner = new RoutePlanner()
+
+    // Alice gives taker and maker some tokens
+    await takerTokenContract.connect(alice).transfer(taker.address, expandTo18DecimalsBN(100000))
+    await makerTokenContract.connect(alice).transfer(maker.address, expandTo18DecimalsBN(100))
+
+    // Taker max-approves the permit2 contract to access his taker token (DAI)
+    await takerTokenContract.connect(taker).approve(permit2.address, MAX_UINT)
+
+    // Maker max-approves the permit2 contract to access his maker token (WETH)
+    await makerTokenContract.connect(maker).approve(permit2.address, MAX_UINT)
+
+    // taker gives the router max approval on permit2
+    await permit2.connect(taker).approve(takerTokenContract.address, router.address, MAX_UINT160, DEADLINE);
+
+    // maker provided signed maker order
+    const makerOrderHash = SignatureTransfer.hash(
+      {
+        permitted: {
+          token: makerTokenContract.address,
+          amount: makerAmount,
+        },
+        spender: router.address,
+        nonce,
+        deadline: DEADLINE,
+      },
+      permit2.address,
+      chainId,
+      {
+        witnessTypeName: 'MakerOrder',
+        witnessType: {
+          MakerOrder: [
+            { name: 'makerToken', type: 'address' },
+            { name: 'takerToken', type: 'address' },
+            { name: 'maker', type: 'address' },
+            { name: 'makerAmount', type: 'uint256' },
+            { name: 'takerAmount', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ]
+        },
+        witness: {
+          makerToken: makerTokenContract.address,
+          takerToken: takerTokenContract.address,
+          maker: maker.address,
+          makerAmount: makerAmount.toString(),
+          takerAmount: takerAmount.toString(),
+          nonce,
+          deadline: DEADLINE,
+        },
+      }
+    );
+
+    const accounts = config.networks.hardhat.accounts;
+    const makerWallet = ethers.Wallet.fromMnemonic(accounts.mnemonic, accounts.path + `/${2}`);
+    const makerKey = makerWallet.privateKey
+    // console.log(`maker privateKey: ${makerKey}`);
+    // console.log(`maker address: ${maker.address}`);
+    // console.log(`maker wallet address: ${makerWallet.address}`);
+    // console.log(`taker address: ${taker.address}`);
+    // console.log(`router address: ${router.address}`);
+    // console.log(`permit2 address: ${permit2.address}`);
+    const ecdaSig = ecsign(hexToBytes(makerOrderHash), hexToBytes(makerKey));
+    // console.log(`maker order hash: ${makerOrderHash}`);
+    // console.log(`ecdaSig.r: ${ecdaSig.r}`);
+    // console.log(`ecdaSig.s: ${ecdaSig.s}`);
+    // console.log(`ecdaSig.v: ${ecdaSig.v}`);
+    signature = toRpcSig(ecdaSig.v, ecdaSig.r, ecdaSig.s);
+    // console.log(`maker order signature: ${signature}`);
+    // const recoveredSignerAddress = ecrecover(hexToBytes(makerOrderHash), ecdaSig.v, ecdaSig.r, ecdaSig.s)
+    // console.log(`recoveredSignerAddress: ${recoveredSignerAddress}`);
+  });
+
+  describe('ERC20 --> ERC20 partial fill', () => {
+    let amountIn: BigNumber;
+  
+    beforeEach(async () => {
+      amountIn = expandTo18DecimalsBN(100);
+    });
+
+    it('Taker as payer, and taker as recipient', async () => {
+      const payerIsUser: boolean = true;
+      const recipient: string = taker.address;
+
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+    it('Taker as payer, and MSG_SENDER as recipient', async () => {
+      const payerIsUser: boolean = true;
+      const recipient: string = MSG_SENDER;
+
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+    it('Taker as payer, and router as recipient', async () => {
+      const payerIsUser: boolean = true;
+      const recipient: string = ADDRESS_THIS;
+
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      planner.addCommand(CommandType.SWEEP, [
+          makerTokenContract.address,
+          SENDER_AS_RECIPIENT,
+          BigNumber.from(0),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+
+    it('Router as payer, and taker as recipient', async () => {
+      const payerIsUser: boolean = false;
+      const recipient: string = taker.address;
+
+      planner.addCommand(CommandType.PERMIT2_TRANSFER_FROM, [
+        takerTokenContract.address,
+        ROUTER_AS_RECIPIENT,
+        amountIn,
+      ]);
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+    it('Router as payer, and MSG_SENDER as recipient', async () => {
+      const payerIsUser: boolean = false;
+      const recipient: string = MSG_SENDER;
+
+      planner.addCommand(CommandType.PERMIT2_TRANSFER_FROM, [
+        takerTokenContract.address,
+        ROUTER_AS_RECIPIENT,
+        amountIn,
+      ]);
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+    it('Router as payer, and router as recipient', async () => {
+      const payerIsUser: boolean = false;
+      const recipient: string = ADDRESS_THIS;
+
+      planner.addCommand(CommandType.PERMIT2_TRANSFER_FROM, [
+        takerTokenContract.address,
+        ROUTER_AS_RECIPIENT,
+        amountIn,
+      ]);
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      planner.addCommand(CommandType.SWEEP, [
+          makerTokenContract.address,
+          SENDER_AS_RECIPIENT,
+          BigNumber.from(0),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(amountIn.mul(makerAmount).div(takerAmount));
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(amountIn);
+    });
+
+    // it('Generate deployed universal router code', async () => {
+    //   const deployedPermit2 = permit2.attach('0x000000000022D473030F116dDEE9F6B43aC78BA3') as Permit2
+    //   const newRouter = (await deployUniversalRouter(deployedPermit2)).connect(taker) as UniversalRouter
+    //   const code = await hre.network.provider.send('eth_getCode', [newRouter.address]);
+    //   console.log(`code: ${code}`)
+    // });
+  });
+  
+  describe('ERC20 --> ERC20 fill all', () => {
+    let amountIn: BigNumber;
+  
+    beforeEach(async () => {
+      amountIn = takerAmount;
+    });
+
+    it('Taker as payer, and taker as recipient', async () => {
+      const payerIsUser: boolean = true;
+      const recipient: string = taker.address;
+
+      planner.addCommand(CommandType.MAKER_ORDER, [
+        recipient,
+        amountIn,
+        payerIsUser,
+        makerTokenContract.address,
+        takerTokenContract.address,
+        maker.address,
+        makerAmount,
+        takerAmount,
+        nonce,
+        DEADLINE,
+        hexToBytes(signature),
+      ]);
+      const { daiBalanceBefore, daiBalanceAfter, wethBalanceBefore, wethBalanceAfter } = await executeRouter(planner);
+      expect(wethBalanceAfter.sub(wethBalanceBefore)).to.be.eq(makerAmount);
+      expect(daiBalanceBefore.sub(daiBalanceAfter)).to.be.eq(takerAmount);
+    });
+  });
+
+  type ExecutionParams = {
+    wethBalanceBefore: BigNumber
+    wethBalanceAfter: BigNumber
+    daiBalanceBefore: BigNumber
+    daiBalanceAfter: BigNumber
+    ethBalanceBefore: BigNumber
+    ethBalanceAfter: BigNumber
+    receipt: TransactionReceipt
+    gasSpent: BigNumber
+  }
+
+  async function executeRouter(planner: RoutePlanner, value?: BigNumberish): Promise<ExecutionParams> {
+    const ethBalanceBefore: BigNumber = await ethers.provider.getBalance(taker.address)
+    const wethBalanceBefore: BigNumber = await makerTokenContract.balanceOf(taker.address)
+    const daiBalanceBefore: BigNumber = await takerTokenContract.balanceOf(taker.address)
+
+    const { commands, inputs } = planner
+    // console.log(`before sending tx`)
+    // console.log(inputs[0])
+    const receipt = await (await router['execute(bytes,bytes[],uint256)'](commands, inputs, DEADLINE, { value, gasLimit: "0x1C9C380" })).wait()
+    // console.log(`after sending tx`)
+    console.log(`Gas used: ${receipt.gasUsed}`)
+    const gasSpent = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+
+    const ethBalanceAfter: BigNumber = await ethers.provider.getBalance(taker.address)
+    const wethBalanceAfter: BigNumber = await makerTokenContract.balanceOf(taker.address)
+    const daiBalanceAfter: BigNumber = await takerTokenContract.balanceOf(taker.address)
+
+    return {
+      wethBalanceBefore,
+      wethBalanceAfter,
+      daiBalanceBefore,
+      daiBalanceAfter,
+      ethBalanceBefore,
+      ethBalanceAfter,
+      receipt,
+      gasSpent,
+    }
+  }
+});

--- a/test/integration-tests/MakerOrderFiller.test.ts
+++ b/test/integration-tests/MakerOrderFiller.test.ts
@@ -82,26 +82,16 @@ describe('Maker order filler tests:', () => {
       permit2.address,
       chainId,
       {
-        witnessTypeName: 'MakerOrder',
+        witnessTypeName: 'MakerOrderWitness',
         witnessType: {
-          MakerOrder: [
-            { name: 'makerToken', type: 'address' },
+          MakerOrderWitness: [
             { name: 'takerToken', type: 'address' },
-            { name: 'maker', type: 'address' },
-            { name: 'makerAmount', type: 'uint256' },
             { name: 'takerAmount', type: 'uint256' },
-            { name: 'nonce', type: 'uint256' },
-            { name: 'deadline', type: 'uint256' },
           ]
         },
         witness: {
-          makerToken: makerTokenContract.address,
           takerToken: takerTokenContract.address,
-          maker: maker.address,
-          makerAmount: makerAmount.toString(),
           takerAmount: takerAmount.toString(),
-          nonce,
-          deadline: DEADLINE,
         },
       }
     );

--- a/test/integration-tests/shared/planner.ts
+++ b/test/integration-tests/shared/planner.ts
@@ -46,6 +46,7 @@ export enum CommandType {
 
   // Added by SwapNet protocol
   CURVE_V1 = 0x23,
+  MAKER_ORDER = 0x24,
 }
 
 const ALLOW_REVERT_FLAG = 0x80
@@ -118,6 +119,7 @@ const ABI_DEFINITION: { [key in CommandType]: string[] } = {
 
   // Added by SwapNet protocol
   [CommandType.CURVE_V1]: ['address', 'address', 'address', 'uint256', 'uint256'],
+  [CommandType.MAKER_ORDER]: ['address', 'uint256', 'bool', 'address', 'address', 'address', 'uint256', 'uint256', 'uint256', 'uint256', 'bytes'],
 }
 
 export class RoutePlanner {


### PR DESCRIPTION
Maker (limit) order feature allows users to trade with professional market makers who have signed a `MakerOrder` which grant this router contract to trade their funds through `Permit2` contract.